### PR TITLE
Updates for crawling in 2023

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,162 @@
+# Python dev (IDEs)
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
-__pycache__

--- a/crawler/.gitignore
+++ b/crawler/.gitignore
@@ -1,5 +1,8 @@
-logs/crawl*.log
+# Crawler results
+logs/*.log
 openwpm/automation/Extension/firefox/dist/
 openwpm/automation/Extension/firefox/node_modules/
 openwpm/automation/Extension/firefox/openwpm.xpi
 openwpm/firefox-bin/
+collected_data/*.sqlite
+filtered_domains/

--- a/crawler/openwpm/scripts/install-firefox.sh
+++ b/crawler/openwpm/scripts/install-firefox.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+set -e
 # Use the Unbranded build that corresponds to a specific Firefox version
 # To upgrade:
 #    1. Go to: https://hg.mozilla.org/releases/mozilla-release/tags.
@@ -8,30 +8,45 @@
 
 # Note this script is **destructive** and will
 # remove the existing Firefox in the OpenWPM directory
+# Update to Firefox 108 from OpenWPM release v0.21.1:
+# https://raw.githubusercontent.com/openwpm/OpenWPM/master/scripts/install-firefox.sh
 
-#TAG='bd5d1f49975deb730064a16b3079edb53c4a5f84' # FIREFOX_80_0_RELEASE
+TAG='a486bbf619936d4f8516c853ea6ffad2d576e2a3' # FIREFOX_108_0_2_RELEASE
 
 case "$(uname -s)" in
-   Darwin)
-     echo 'Mac OSX Unsupported'
-     exit 1
-     ;;
-   Linux)
-     echo 'Installing for Linux'
-     OS='linux'
-     TARGET_SUFFIX='.tar.bz2'
-     ;;
-   *)
-     echo 'Your OS is not supported. Aborting'
-     exit 1
-     ;;
+Darwin)
+  echo 'Installing for Mac OSX'
+  OS='macosx'
+  TARGET_SUFFIX='.dmg'
+  ;;
+Linux)
+  echo 'Installing for Linux'
+  OS='linux'
+  TARGET_SUFFIX='.tar.bz2'
+  ;;
+*)
+  echo 'Your OS is not supported. Aborting'
+  exit 1
+  ;;
 esac
 
-#UNBRANDED_RELEASE_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.revision.${TAG}.firefox.${OS}64-add-on-devel/artifacts/public/build/target${TARGET_SUFFIX}"
-#wget -q "$UNBRANDED_RELEASE_BUILD"
+UNBRANDED_RELEASE_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.revision.${TAG}.firefox.${OS}64-add-on-devel/artifacts/public/build/target${TARGET_SUFFIX}"
+wget -q "$UNBRANDED_RELEASE_BUILD"
 
-tar jxf ./firefox80.tar.bz2
-rm -rf firefox-bin
-mv firefox firefox-bin
+case "$(uname -s)" in
+Darwin)
+  rm -rf Nightly.app || true
+  hdiutil attach -nobrowse -mountpoint /Volumes/firefox-tmp target.dmg
+  cp -r /Volumes/firefox-tmp/Nightly.app .
+  hdiutil detach /Volumes/firefox-tmp
+  rm target.dmg
+  ;;
+Linux)
+  tar jxf target.tar.bz2
+  rm -rf firefox-bin
+  mv firefox firefox-bin
+  rm target.tar.bz2
+  ;;
+esac
 
-echo 'Firefox successfully installed'
+echo 'Firefox succesfully installed'

--- a/crawler/openwpm/scripts/install-firefox80-usenix.sh
+++ b/crawler/openwpm/scripts/install-firefox80-usenix.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Use the Unbranded build that corresponds to a specific Firefox version
+# To upgrade:
+#    1. Go to: https://hg.mozilla.org/releases/mozilla-release/tags.
+#    2. Find the commit hash for the Firefox release version you'd like to upgrade to.
+#    3. Update the `TAG` variable below to that hash.
+
+# Note this script is **destructive** and will
+# remove the existing Firefox in the OpenWPM directory
+
+#TAG='bd5d1f49975deb730064a16b3079edb53c4a5f84' # FIREFOX_80_0_RELEASE
+
+case "$(uname -s)" in
+   Darwin)
+     echo 'Mac OSX Unsupported'
+     exit 1
+     ;;
+   Linux)
+     echo 'Installing for Linux'
+     OS='linux'
+     TARGET_SUFFIX='.tar.bz2'
+     ;;
+   *)
+     echo 'Your OS is not supported. Aborting'
+     exit 1
+     ;;
+esac
+
+#UNBRANDED_RELEASE_BUILD="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-release.revision.${TAG}.firefox.${OS}64-add-on-devel/artifacts/public/build/target${TARGET_SUFFIX}"
+#wget -q "$UNBRANDED_RELEASE_BUILD"
+
+tar jxf ./firefox80.tar.bz2
+rm -rf firefox-bin
+mv firefox firefox-bin
+
+echo 'Firefox successfully installed'

--- a/crawler/run_consent_crawl.py
+++ b/crawler/run_consent_crawl.py
@@ -15,11 +15,12 @@ Currently supports collecting data from the following CMPs:
 - Termly
 ----------------------------------------
 Usage:
-    run_consent_crawl.py (cookiebot|onetrust|termly|all|none) (--num_browsers <NUM>) (--url <u> | --pkl <fpkl> | --file <fpath> | --csv <csvpath> )... [--use_db <DB_NAME>]
+    run_consent_crawl.py (cookiebot|onetrust|termly|all|none) (--num_browsers <NUM>) (--url <u> | --pkl <fpkl> | --file <fpath> | --csv <csvpath> | --profile_tar <prof_path> )... [--use_db <DB_NAME>]
     run_consent_crawl.py --help
 
 Options:
     -n --num_browsers <NUM>   Number of browsers to use in parallel
+    --profile_tar <prof_path> Location of browser profile to be used
     -d --use_db <DB_NAME>     Use specified database file to add rows to.
     -u --url <u>              URL string to crawl
     -p --pkl <fpkl>           File path to pickled list of urls to parse
@@ -43,7 +44,7 @@ completed: int = 0
 interrupted: int = 0
 
 
-def setup_browser_config(browser_param: Dict) -> None:
+def setup_browser_config(cargs: Dict, browser_param: Dict) -> None:
     """
     Set up configuration for the given browser dictionary.
     The general idea is to have the browser be as permissive as possible towards cookies,
@@ -65,7 +66,10 @@ def setup_browser_config(browser_param: Dict) -> None:
     # tar file must be named "profile.tar.gz"
     ## Firefox profile dated 24. November 2020. May need to be replaced in the future.
     ## Comes with Consent-O-Matic preinstalled and preconfigured.
-    browser_param['profile_tar'] = "./crawler_profile_consentomatic_accept_all/"
+    if cargs["--profile_tar"]:
+        browser_param['profile_tar'] = cargs["--profile_tar"]
+    else:
+        browser_param['profile_tar'] = "./crawler_profile_consentomatic_accept_all/"
 
     # randomizes screen resolution and user agent string, only if browser profile not already set
     # since we have a fixed profile, we don't need this
@@ -123,7 +127,7 @@ def main():
     num_browsers = int(cargs["--num_browsers"])
     manager_params, browser_params = TaskManager.load_default_params(num_browsers)
     for i in range(num_browsers):
-        setup_browser_config(browser_params[i])
+        setup_browser_config(cargs, browser_params[i])
 
     # define output directories
     manager_params["output_format"] = "local"

--- a/crawler/run_presence_crawl.py
+++ b/crawler/run_presence_crawl.py
@@ -53,7 +53,8 @@ from shared_utils import retrieve_cmdline_urls
 logger = logging.getLogger("presence-crawl")
 
 # Cookiebot CDN domain
-cb_base_pat = re.compile("https://consent\\.cookiebot\\.com/")
+cb_base_pat = re.compile("https://consent\\.cookiebot\\.(com|eu)/")
+cb_script_name = re.compile("cb-main\\.js")  # for websites the load CB dynamically
 
 # OneTrust CDNs
 onetrust_pattern_A = re.compile("(https://cdn-apac\\.onetrust\\.com)")
@@ -102,8 +103,9 @@ class QuickCrawlResult(IntEnum):
 def check_cookiebot_presence(resp: requests.Response) -> bool:
     """ Check whether Cookiebot is referenced on the website """
     psource = resp.text
-    matchobj = cb_base_pat.search(psource, re.IGNORECASE)
-    return matchobj is not None
+    matchobj1 = cb_base_pat.search(psource, re.IGNORECASE)
+    matchobj2 = cb_script_name.search(psource, re.IGNORECASE)
+    return matchobj1 is not None or matchobj2 is not None
 
 
 def check_onetrust_presence(resp: requests.Response) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests~=2.25.1
 scikit-learn~=0.24.1
 sklearn~=0.0
 tqdm~=4.59.0
+tblib~=1.7.0


### PR DESCRIPTION
This aggregates multiple changes proposed also by @PatriceKast.

* Cookiebot detection independently of TLD (.com/.eu)
* Firefox installation bumped to 108 version (from OpenWPM release v0.21.1) and tested that it works
  * Old Firefox 80 (from USENIX publication) left in `crawler/openwpm/scripts/install-firefox80-usenix.sh`
* Allow CLI configuration of profile for more automated crawling
* Added missing requirement `tblib`

Note about @dependabot vulnerabilities warnings: they are dependency in OpenWPM and without updating the whole OpenWPM (a lot of effort with the current codebase that diverged with OpenWPM v0.13), it might cause unpredictible instabilities. Given that we only scan websites, even if the forgery would allow attackers to modify payload or crash the crawl for given website, it would affect only small number of websites. So we keep this as it unchanged.